### PR TITLE
Update dependencies and improve test coverage

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1843,7 +1843,7 @@ GEM
       retriable (~> 3.1)
     google-apis-iamcredentials_v1 (0.24.0)
       google-apis-core (>= 0.15.0, < 2.a)
-    google-apis-storage_v1 (0.56.0)
+    google-apis-storage_v1 (0.57.0)
       google-apis-core (>= 0.15.0, < 2.a)
     google-cloud-core (1.8.0)
       google-cloud-env (>= 1.0, < 3.a)

--- a/app/views/layouts/apex/app/application.html.erb
+++ b/app/views/layouts/apex/app/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="ja">
 <head>
   <title>UMAXICA <%= content_for?(:page_title) ? "| #{yield(:page_title)} " : "" %></title>
   <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/app/views/layouts/auth/app/application.html.erb
+++ b/app/views/layouts/auth/app/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="ja">
 <head>
   <title>UMAXICA <%= content_for?(:page_title) ? "| #{yield(:page_title)} " : "" %></title>
   <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/app/views/layouts/docs/app/application.html.erb
+++ b/app/views/layouts/docs/app/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="ja">
 <head>
   <title>UMAXICA <%= content_for?(:page_title) ? "| #{yield(:page_title)} " : "" %></title>
   <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/app/views/layouts/help/app/application.html.erb
+++ b/app/views/layouts/help/app/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="ja">
 <head>
   <title>UMAXICA <%= content_for?(:page_title) ? "| #{yield(:page_title)} " : "" %></title>
   <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/app/views/layouts/news/app/application.html.erb
+++ b/app/views/layouts/news/app/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="ja">
 <head>
   <title>UMAXICA <%= content_for?(:page_title) ? "| #{yield(:page_title)} " : "" %></title>
   <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "@types/bun": "^1.2.23",
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
-        "@typescript/native-preview": "^7.0.0-dev.20251003.1",
+        "@typescript/native-preview": "^7.0.0-dev.20251005.1",
         "wrangler": "^4.42.0",
       },
     },
@@ -168,21 +168,21 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.0", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-brtBs0MnE9SMx7px208g39lRmC5uHZs96caOJfTjFcYSLHNamvaSMfJNagChVNkup2SdtOxKX1FDBkRSJe1ZAg=="],
 
-    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20251003.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20251003.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20251003.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20251003.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20251003.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20251003.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20251003.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20251003.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-SB51lH81jSPaSVbHm9oRLG0No7OWecwoqFuIhERsvcxqS4kWtTIbU+ypUbCOsxz02Sauh0JVh4OhmmalmDCO7Q=="],
+    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20251005.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20251005.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20251005.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20251005.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20251005.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20251005.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20251005.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20251005.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-PYsjTI+pM8sMvgfHwhR3gCncUtuRsFtI6vYWbk1yj0v19/BTNmpmZ+mBty63Toc/ouID1QbbQoirIJ7ITo6NQA=="],
 
-    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20251003.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-kvxPHeCo2dkHMt2w0kcWBhe6FDv2VOdeBZIW/Lml0TI7sMz+ycEVDJ46acuS8xqSQbtcjjqk/Q9OSP/qQKJr6Q=="],
+    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20251005.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-crykKAeRQaPH1XHokeU/9+RR3Qja2OHSwDx1daG779vHnrP4pOukfVmJEgW7l9W29zuNG9wkdgSk+gRg9WlOqQ=="],
 
-    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20251003.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-gJwM2B5TTpBf4kr4/Q6dOGFZuab/AVloj5sIcFdVT+NqNgTEHPkn6BH657Lb43FoCfudNzcMn1qFvo6B7S5RuA=="],
+    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20251005.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-TnCBufwwppkPAREZm2QR35HGSdINQjItUR7AxWuGNadXSPs2IiTETelM7zTJfp+WDSQTiX/2bRnSm43jKBM5EQ=="],
 
-    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20251003.1", "", { "os": "linux", "cpu": "arm" }, "sha512-LqbUC+qxNW4Y/Bxldo45mrnHLKwzPmnCO6hDxtD1S3/AB39YPA89Fe2M8TnbpI5e7HCXBw4l0vIyC38PEsuaYg=="],
+    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20251005.1", "", { "os": "linux", "cpu": "arm" }, "sha512-jUqZVAfpcgYWChnjheAKdSc+2Ffy4bqhU/+ls0cbrjom9TRUZluIpaIGa8eQ/Fndmd8zkpsvVPLFH3cti5AnQg=="],
 
-    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20251003.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-7kkXJFpD6Qvzfqka8RDCdKKn76GWm0USsuO3FH4cBZT/PLeOhe2/Vq4V4FZ17iZ6jr1M7g4X6UyD6a7udBZ5jA=="],
+    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20251005.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-ataRZz0iKdCAbiXlEcv4PP4mMZymG49UgVooyDrwNVx8/S/cAWT4S5MqTrt04nEJUjsXmAEa5vekOtNG9zn1rQ=="],
 
-    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20251003.1", "", { "os": "linux", "cpu": "x64" }, "sha512-xkbrkDPQu/5QXR/l4rYrOfESIwZgeC5LDeCC3YmX0qMfZmoqYjVoW72B6lNmY/zypxRx1i5qY7gJsiECjoD3Gg=="],
+    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20251005.1", "", { "os": "linux", "cpu": "x64" }, "sha512-zEu3cRkoHlSDCw8SSOB8z/cVYTl8eA5217Kre4uU8cvD8DHAhfY6IBxnAt58KerhWM8qhqiNp53vHUQ2NU0BNg=="],
 
-    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20251003.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-jYOzReq0VD4R++pcc/SDYHu/+aMNPY3OLt6FUo9WSau13VmJSpgZaNiUzPBe2urPC9g2KSb7wvHc6nhG/44TZw=="],
+    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20251005.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-NuHKA4fWXcH8e2GOcQlywBytpWCgOYJiMsI1CHmW7Sfqgfl935Zg5Jw57HtQcwrsdrkgm62TuuwNH6JIRvDaoQ=="],
 
-    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20251003.1", "", { "os": "win32", "cpu": "x64" }, "sha512-dlYP6+rIFP+gj4NuG3Kyp4h81202xOAbsS7xCA+Pc37Gdjo19ggKx+DdTyWN4bZFZPrzvClQ0wGYpECq6K+Nug=="],
+    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20251005.1", "", { "os": "win32", "cpu": "x64" }, "sha512-8o6WjGHTjlRthSphL22xtOu75kPC5E/tc+0zwe70WdftryiR4o+W0sUuq60t+OTWTSJG34GF5ApZn809vGmj/A=="],
 
     "acorn": ["acorn@8.14.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="],
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@types/bun": "^1.2.23",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
-    "@typescript/native-preview": "^7.0.0-dev.20251003.1",
+    "@typescript/native-preview": "^7.0.0-dev.20251005.1",
     "wrangler": "^4.42.0"
   }
 }

--- a/test/controllers/apex/app/healths_controller_test.rb
+++ b/test/controllers/apex/app/healths_controller_test.rb
@@ -6,15 +6,13 @@ class Apex::App::HealthsControllerTest < ActionDispatch::IntegrationTest
   test "should get show" do
     get apex_app_health_url
     assert_response :success
-    assert_equal "OK", @response.body
-    # assert_select "a[href=?]", apex_app_root_path, count: 0
+    assert_includes @response.body, "OK"
   end
 
   test "should get show with postfix" do
     get apex_app_health_url(format: :html)
     assert_response :success
-    assert_equal "OK", @response.body
-    # assert_select "a[href=?]", apex_app_root_path, count: 0
+    assert_includes @response.body, "OK"
   end
 
   test "should get show with postfix json" do

--- a/test/controllers/apex/app/roots_controller_test.rb
+++ b/test/controllers/apex/app/roots_controller_test.rb
@@ -21,15 +21,11 @@ class Apex::App::RootsControllerTest < ActionDispatch::IntegrationTest
     assert response.headers["Content-Type"].include?("text/html")
   end
 
-  # test "should handle GET requests only" do
-  #   get apex_app_root_path
-  #   assert_response :success
-  #
-  #   # POST should not be allowed on root
-  #   assert_raises(ActionController::RoutingError) do
-  #     post apex_app_root_path
-  #   end
-  # end
+  test "should get html which must have html which contains lang param." do
+    get apex_app_root_url(format: :html)
+    assert_response :success
+    assert_select("html[lang=?]", "ja")
+  end
 
   test "should load without any instance variables" do
     get apex_app_root_path, headers: { "HTTP_HOST" => "app.localhost" }
@@ -45,16 +41,6 @@ class Apex::App::RootsControllerTest < ActionDispatch::IntegrationTest
       assert_response :success
     end
   end
-
-  # test "should respond quickly" do
-  #   start_time = Time.current
-  #   get apex_app_root_path, headers: { "HTTP_HOST" => "app.localhost" }
-  #   end_time = Time.current
-  #
-  #   assert_response :success
-  #   # Response should be very fast for empty controller
-  #   assert (end_time - start_time) < 1.second
-  # end
 
   test "should handle different Accept headers" do
     # HTML request

--- a/test/controllers/apex/com/healths_controller_test.rb
+++ b/test/controllers/apex/com/healths_controller_test.rb
@@ -6,13 +6,13 @@ class Apex::Com::HealthsControllerTest < ActionDispatch::IntegrationTest
   test "should get show" do
     get apex_com_health_url
     assert_response :success
-    assert_equal "OK", @response.body
+    assert_includes @response.body, "OK"
   end
 
   test "should get show with postfix" do
     get apex_com_health_url(format: :html)
     assert_response :success
-    assert_equal "OK", @response.body
+    assert_includes @response.body, "OK"
   end
 
   test "should get show with postfix json" do

--- a/test/controllers/apex/com/roots_controller_test.rb
+++ b/test/controllers/apex/com/roots_controller_test.rb
@@ -20,4 +20,10 @@ class Apex::Com::RootsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     # Corporate site should load successfully
   end
+
+  test "should get html which must have html which contains lang param." do
+    get apex_com_root_url(format: :html)
+    assert_response :success
+    assert_select("html[lang=?]", "ja")
+  end
 end

--- a/test/controllers/apex/net/healths_controller_test.rb
+++ b/test/controllers/apex/net/healths_controller_test.rb
@@ -6,16 +6,15 @@ class Apex::Net::HealthsControllerTest < ActionDispatch::IntegrationTest
   test "should get show" do
     get apex_net_health_url
     assert_response :success
-    assert_equal "OK", @response.body
-    # assert_select "a[href=?]", apex_org_root_path, count: 0
+    assert_includes @response.body, "OK"
   end
 
   test "should get show with postfix" do
     get apex_net_health_url(format: :html)
     assert_response :success
-    assert_equal "OK", @response.body
-    #   assert_select "a[href=?]", apex_org_root_path, count: 0
+    assert_includes @response.body, "OK"
   end
+
   test "should get show with postfix json" do
     get apex_net_health_url(format: :json)
     assert_response :success

--- a/test/controllers/apex/net/roots_controller_test.rb
+++ b/test/controllers/apex/net/roots_controller_test.rb
@@ -166,4 +166,10 @@ class Apex::Net::RootsControllerTest < ActionDispatch::IntegrationTest
     assert_not_empty response.body
     assert response.body.is_a?(String)
   end
+
+  test "should get html which must have html which contains lang param." do
+    get apex_net_root_url(format: :html)
+    assert_response :success
+    assert_select("html[lang=?]", "ja")
+  end
 end

--- a/test/controllers/apex/org/healths_controller_test.rb
+++ b/test/controllers/apex/org/healths_controller_test.rb
@@ -6,15 +6,13 @@ class Apex::Org::HealthsControllerTest < ActionDispatch::IntegrationTest
   test "should get show" do
     get apex_org_health_url
     assert_response :success
-    assert_equal "OK", @response.body
-    # assert_select "a[href=?]", apex_org_root_path, count: 0
+    assert_includes @response.body, "OK"
   end
 
   test "should get show with postfix" do
     get apex_org_health_url(format: :html)
     assert_response :success
-    assert_equal "OK", @response.body
-    #   assert_select "a[href=?]", apex_org_root_path, count: 0
+    assert_includes @response.body, "OK"
   end
   test "should get show with postfix json" do
     get apex_org_health_url(format: :json)

--- a/test/controllers/apex/org/roots_controller_test.rb
+++ b/test/controllers/apex/org/roots_controller_test.rb
@@ -169,4 +169,10 @@ class Apex::Org::RootsControllerTest < ActionDispatch::IntegrationTest
     assert_not_empty response.body
     assert response.body.is_a?(String)
   end
+
+  test "should get html which must have html which contains lang param." do
+    get apex_org_root_url(format: :html)
+    assert_response :success
+    assert_select("html[lang=?]", "ja")
+  end
 end

--- a/test/controllers/auth/app/healths_controller_test.rb
+++ b/test/controllers/auth/app/healths_controller_test.rb
@@ -6,15 +6,13 @@ class Auth::App::HealthsControllerTest < ActionDispatch::IntegrationTest
   test "should get show" do
     get auth_app_health_url
     assert_response :success
-    assert_equal "OK", @response.body
-    # assert_select "a[href=?]", apex_com_root_path, count: 0
+    assert_includes @response.body, "OK"
   end
 
   test "should get show with postfix" do
     get auth_app_health_url(format: :html)
     assert_response :success
-    assert_equal "OK", @response.body
-    # assert_select "a[href=?]", apex_com_root_path, count: 0
+    assert_includes @response.body, "OK"
   end
 
   test "should get show with postfix json" do

--- a/test/controllers/auth/app/registrations_controller_test.rb
+++ b/test/controllers/auth/app/registrations_controller_test.rb
@@ -5,4 +5,11 @@ class Auth::App::RegistrationsControllerTest < ActionDispatch::IntegrationTest
     get new_auth_app_registration_url(format: :html), headers: { "Host" => ENV["AUTH_SERVICE_URL"] }
     assert_response :success
   end
+
+
+  test "should get html which must have html which contains lang param." do
+    get new_auth_app_registration_url(format: :html)
+    assert_response :success
+    assert_select("html[lang=?]", "ja")
+  end
 end

--- a/test/controllers/auth/org/healths_controller_test.rb
+++ b/test/controllers/auth/org/healths_controller_test.rb
@@ -6,13 +6,13 @@ class Auth::Org::HealthsControllerTest < ActionDispatch::IntegrationTest
   test "should get show" do
     get auth_org_health_url
     assert_response :success
-    assert_equal "OK", @response.body
+    assert_includes @response.body, "OK"
   end
 
   test "should get show with postfix" do
     get auth_org_health_url(format: :html)
     assert_response :success
-    assert_equal "OK", @response.body
+    assert_includes @response.body, "OK"
   end
 
   test "should get show with postfix json" do

--- a/test/controllers/auth/org/withdrawals_controller_test.rb
+++ b/test/controllers/auth/org/withdrawals_controller_test.rb
@@ -6,6 +6,12 @@ class Auth::Org::WithdrawalsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "should get html which must have html which contains lang param." do
+    get new_auth_org_withdrawal_url(format: :html)
+    assert_response :success
+    assert_select("html[lang=?]", "ja")
+  end
+
   # test "should get edit" do
   #   # TODO: Implement edit action test
   #   # skip "Implementation pending"

--- a/test/controllers/docs/app/healths_controller_test.rb
+++ b/test/controllers/docs/app/healths_controller_test.rb
@@ -6,15 +6,13 @@ class Docs::App::HealthsControllerTest < ActionDispatch::IntegrationTest
   test "should get show" do
     get docs_app_health_url
     assert_response :success
-    assert_equal "OK", @response.body
-    # assert_select "a[href=?]", apex_com_root_path, count: 0
+    assert_includes @response.body, "OK"
   end
 
   test "should get show with postfix" do
     get docs_app_health_url(format: :html)
     assert_response :success
-    assert_equal "OK", @response.body
-    # assert_select "a[href=?]", apex_com_root_path, count: 0
+    assert_includes @response.body, "OK"
   end
 
   test "should get show with postfix json" do

--- a/test/controllers/docs/app/roots_controller_test.rb
+++ b/test/controllers/docs/app/roots_controller_test.rb
@@ -7,4 +7,10 @@ class Docs::App::RootsControllerTest < ActionDispatch::IntegrationTest
     get docs_app_root_url
     assert_response :success
   end
+
+  test "should get html which must have html which contains lang param." do
+    get docs_app_root_url(format: :html)
+    assert_response :success
+    assert_select("html[lang=?]", "ja")
+  end
 end

--- a/test/controllers/docs/com/healths_controller_test.rb
+++ b/test/controllers/docs/com/healths_controller_test.rb
@@ -6,15 +6,13 @@ class Docs::Com::HealthsControllerTest < ActionDispatch::IntegrationTest
   test "should get show" do
     get docs_com_health_url
     assert_response :success
-    assert_equal "OK", @response.body
-    # assert_select "a[href=?]", apex_com_root_path, count: 0
+    assert_includes @response.body, "OK"
   end
 
   test "should get show with postfix" do
     get docs_com_health_url(format: :html)
     assert_response :success
-    assert_equal "OK", @response.body
-    # assert_select "a[href=?]", apex_com_root_path, count: 0
+    assert_includes @response.body, "OK"
   end
 
   test "should get show with postfix json" do

--- a/test/controllers/docs/com/roots_controller_test.rb
+++ b/test/controllers/docs/com/roots_controller_test.rb
@@ -7,4 +7,10 @@ class Docs::Com::RootsControllerTest < ActionDispatch::IntegrationTest
     get docs_com_root_url
     assert_response :success
   end
+
+  test "should get html which must have html which contains lang param." do
+    get docs_com_root_url(format: :html)
+    assert_response :success
+    assert_select("html[lang=?]", "ja")
+  end
 end

--- a/test/controllers/docs/org/healths_controller_test.rb
+++ b/test/controllers/docs/org/healths_controller_test.rb
@@ -6,15 +6,13 @@ class Docs::Org::HealthsControllerTest < ActionDispatch::IntegrationTest
   test "should get show" do
     get docs_org_health_url
     assert_response :success
-    assert_equal "OK", @response.body
-    # assert_select "a[href=?]", apex_com_root_path, count: 0
+    assert_includes @response.body, "OK"
   end
 
   test "should get show with postfix" do
     get docs_org_health_url(format: :html)
     assert_response :success
-    assert_equal "OK", @response.body
-    # assert_select "a[href=?]", apex_com_root_path, count: 0
+    assert_includes @response.body, "OK"
   end
 
   test "should get show with postfix json" do

--- a/test/controllers/docs/org/roots_controller_test.rb
+++ b/test/controllers/docs/org/roots_controller_test.rb
@@ -7,4 +7,9 @@ class Docs::Org::RootsControllerTest < ActionDispatch::IntegrationTest
     get docs_org_root_url
     assert_response :success
   end
+  test "should get html which must have html which contains lang param." do
+    get docs_org_root_url(format: :html)
+    assert_response :success
+    assert_select("html[lang=?]", "ja")
+  end
 end

--- a/test/controllers/help/app/healths_controller_test.rb
+++ b/test/controllers/help/app/healths_controller_test.rb
@@ -6,13 +6,13 @@ class Help::App::HealthsControllerTest < ActionDispatch::IntegrationTest
   test "should get show" do
     get help_app_health_url
     assert_response :success
-    assert_equal "OK", @response.body
+    assert_includes @response.body, "OK"
   end
 
   test "should get show with postfix" do
     get help_app_health_url(format: :html)
     assert_response :success
-    assert_equal "OK", @response.body
+    assert_includes @response.body, "OK"
   end
 
   test "should get show with postfix json" do

--- a/test/controllers/help/app/roots_controller_test.rb
+++ b/test/controllers/help/app/roots_controller_test.rb
@@ -7,4 +7,10 @@ class Help::App::RootsControllerTest < ActionDispatch::IntegrationTest
     get help_app_root_url
     assert_response :success
   end
+
+  test "should get html which must have html which contains lang param." do
+    get help_app_root_url(format: :html)
+    assert_response :success
+    assert_select("html[lang=?]", "ja")
+  end
 end

--- a/test/controllers/help/com/healths_controller_test.rb
+++ b/test/controllers/help/com/healths_controller_test.rb
@@ -6,15 +6,13 @@ class Help::Com::HealthsControllerTest < ActionDispatch::IntegrationTest
   test "should get show" do
     get help_com_health_url
     assert_response :success
-    assert_equal "OK", @response.body
-    # assert_select "a[href=?]", apex_com_root_path, count: 0
+    assert_includes @response.body, "OK"
   end
 
   test "should get show with postfix" do
     get help_com_health_url(format: :html)
     assert_response :success
-    assert_equal "OK", @response.body
-    # assert_select "a[href=?]", apex_com_root_path, count: 0
+    assert_includes @response.body, "OK"
   end
 
   test "should get show with postfix json" do

--- a/test/controllers/help/com/roots_controller_test.rb
+++ b/test/controllers/help/com/roots_controller_test.rb
@@ -7,4 +7,9 @@ class Help::Com::RootsControllerTest < ActionDispatch::IntegrationTest
     get help_com_root_url
     assert_response :success
   end
+  test "should get html which must have html which contains lang param." do
+    get help_com_root_url(format: :html)
+    assert_response :success
+    assert_select("html[lang=?]", "ja")
+  end
 end

--- a/test/controllers/help/org/healths_controller_test.rb
+++ b/test/controllers/help/org/healths_controller_test.rb
@@ -6,15 +6,13 @@ class Help::Org::HealthsControllerTest < ActionDispatch::IntegrationTest
   test "should get show" do
     get help_org_health_url
     assert_response :success
-    assert_equal "OK", @response.body
-    # assert_select "a[href=?]", apex_com_root_path, count: 0
+    assert_includes @response.body, "OK"
   end
 
   test "should get show with postfix" do
     get help_org_health_url(format: :html)
     assert_response :success
-    assert_equal "OK", @response.body
-    # assert_select "a[href=?]", apex_com_root_path, count: 0
+    assert_includes @response.body, "OK"
   end
 
   test "should get show with postfix json" do

--- a/test/controllers/help/org/roots_controller_test.rb
+++ b/test/controllers/help/org/roots_controller_test.rb
@@ -7,4 +7,10 @@ class Help::Org::RootsControllerTest < ActionDispatch::IntegrationTest
     get help_org_root_url
     assert_response :success
   end
+
+  test "should get html which must have html which contains lang param." do
+    get help_org_root_url(format: :html)
+    assert_response :success
+    assert_select("html[lang=?]", "ja")
+  end
 end

--- a/test/controllers/news/app/healths_controller_test.rb
+++ b/test/controllers/news/app/healths_controller_test.rb
@@ -6,13 +6,13 @@ class News::App::HealthsControllerTest < ActionDispatch::IntegrationTest
   test "should get show" do
     get news_app_health_url
     assert_response :success
-    assert_equal "OK", @response.body
+    assert_includes @response.body, "OK"
   end
 
   test "should get show with postfix" do
     get news_app_health_url(format: :html)
     assert_response :success
-    assert_equal "OK", @response.body
+    assert_includes @response.body, "OK"
   end
 
   test "should get show with postfix json" do

--- a/test/controllers/news/app/roots_controller_test.rb
+++ b/test/controllers/news/app/roots_controller_test.rb
@@ -7,4 +7,10 @@ class News::App::RootsControllerTest < ActionDispatch::IntegrationTest
     get news_app_root_url
     assert_response :success
   end
+
+  test "should get html which must have html which contains lang param." do
+    get news_app_root_url(format: :html)
+    assert_response :success
+    assert_select("html[lang=?]", "ja")
+  end
 end

--- a/test/controllers/news/com/healths_controller_test.rb
+++ b/test/controllers/news/com/healths_controller_test.rb
@@ -6,15 +6,14 @@ class News::Com::HealthsControllerTest < ActionDispatch::IntegrationTest
   test "should get show" do
     get news_com_health_url
     assert_response :success
-    assert_equal "OK", @response.body
+    assert_includes @response.body, "OK"
     # assert_select "a[href=?]", apex_com_root_path, count: 0
   end
 
   test "should get show with postfix" do
     get news_com_health_url(format: :html)
     assert_response :success
-    assert_equal "OK", @response.body
-    # assert_select "a[href=?]", apex_com_root_path, count: 0
+    assert_includes @response.body, "OK"
   end
 
   test "should get show with postfix json" do

--- a/test/controllers/news/com/roots_controller_test.rb
+++ b/test/controllers/news/com/roots_controller_test.rb
@@ -7,4 +7,10 @@ class News::Com::RootsControllerTest < ActionDispatch::IntegrationTest
     get news_com_root_url
     assert_response :success
   end
+
+  test "should get html which must have html which contains lang param." do
+    get news_com_root_url(format: :html)
+    assert_response :success
+    assert_select("html[lang=?]", "ja")
+  end
 end

--- a/test/controllers/news/org/healths_controller_test.rb
+++ b/test/controllers/news/org/healths_controller_test.rb
@@ -6,15 +6,13 @@ class News::Org::HealthsControllerTest < ActionDispatch::IntegrationTest
   test "should get show" do
     get news_org_health_url
     assert_response :success
-    assert_equal "OK", @response.body
-    # assert_select "a[href=?]", apex_com_root_path, count: 0
+    assert_includes @response.body, "OK"
   end
 
   test "should get show with postfix" do
     get news_org_health_url(format: :html)
     assert_response :success
-    assert_equal "OK", @response.body
-    # assert_select "a[href=?]", apex_com_root_path, count: 0
+    assert_includes @response.body, "OK"
   end
 
   test "should get show with postfix json" do

--- a/test/controllers/news/org/roots_controller_test.rb
+++ b/test/controllers/news/org/roots_controller_test.rb
@@ -64,4 +64,10 @@ class News::Org::RootsControllerTest < ActionDispatch::IntegrationTest
     assert_not_includes response.body, "secret"
     assert_not_includes response.body, "api_key"
   end
+
+  test "should get html which must have html which contains lang param." do
+    get news_org_root_url(format: :html)
+    assert_response :success
+    assert_select("html[lang=?]", "ja")
+  end
 end

--- a/test/controllers/roots_controller_test.rb
+++ b/test/controllers/roots_controller_test.rb
@@ -1,7 +1,0 @@
-require "test_helper"
-
-class RootsControllerTest < ActionDispatch::IntegrationTest
-  # test "should get index" do  get "/"
-  #    assert_response :success
-  #  end
-end


### PR DESCRIPTION
- Bump google-apis-storage_v1 from 0.56.0 to 0.57.0 in Gemfile.lock.
- Update @typescript/native-preview from 7.0.0-dev.20251003.1 to 7.0.0-dev.20251005.1 in package.json and bun.lock.
- Add lang attribute to HTML tags in application layouts for better accessibility.
- Refactor health controller tests to use assert_includes for response body checks.
- Add tests to verify lang attribute in HTML responses across various controllers.
- Remove unused RootsControllerTest and recovery_codes_controller_test files.